### PR TITLE
Feature/expose pathing to methods

### DIFF
--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Controllers/CollectionManagementController.Abstract.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Controllers/CollectionManagementController.Abstract.psm1
@@ -54,8 +54,9 @@ class CollectionManagementController : IsAbstract {
 
 
     #region Static Methods
-    [Void] Static Build([IContentModel] $contentModel, [Bool] $loadProperties, [Bool] $generateHash) {
-        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+    [Void] Static Build([IContentModel] $contentModel, [String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) {
+        
+        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
         
         $handler.Build($loadProperties, $generateHash, $filesystemProvider)
@@ -63,8 +64,9 @@ class CollectionManagementController : IsAbstract {
         $filesystemProvider.Dispose()
     }
 
-    [Void] Static Rebuild([IContentModel] $contentModel, [Bool] $loadProperties, [Bool] $generateHash) {
-        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+    [Void] Static Rebuild([IContentModel] $contentModel, [String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) {
+        
+        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
         
         $handler.Rebuild($loadProperties, $generateHash, $filesystemProvider)
@@ -72,8 +74,9 @@ class CollectionManagementController : IsAbstract {
         $filesystemProvider.Dispose()
     }
 
-    [Void] Static Load([IContentModel] $contentModel, [String] $indexFilePath, [Bool] $loadProperties, [Bool] $generateHash) {
-        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+    [Void] Static Load([IContentModel] $contentModel, [String] $indexFilePath, [Bool] $loadProperties, [Bool] $generateHash, [String] $contentPath) {
+        
+        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
         [IModelPersistenceHandler] $persistenceHandler = [ModelPersistenceHandler]::new()
         [IModelManipulationHandler] $manipulationHandler = [ModelManipulationHandler]::new($contentModel)
         
@@ -83,8 +86,9 @@ class CollectionManagementController : IsAbstract {
         $filesystemProvider.Dispose()
     }
 
-    [Void] Static Save([IContentModel] $contentModel, [String] $indexFilePath, [Bool] $loadProperties, [Bool] $generateHash) {
-        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+    [Void] Static Save([IContentModel] $contentModel, [String] $indexFilePath, [Bool] $loadProperties, [Bool] $generateHash, [String] $contentPath) {
+        
+        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
         [IModelPersistenceHandler] $persistenceHandler = [ModelPersistenceHandler]::new()
         [IModelManipulationHandler] $manipulationHandler = [ModelManipulationHandler]::new($contentModel)
         
@@ -93,113 +97,113 @@ class CollectionManagementController : IsAbstract {
         $filesystemProvider.Dispose()
     }
 
-    [Bool] Static AlterActor ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterActor ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
 
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
         
         [Bool] $alterations = $handler.AlterSubject([ActorBO]::new($contentModel.Config), $contentModel.Actors, $fromName, $toName)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterAlbum ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterAlbum ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
 
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterSubject([AlbumBO]::new($contentModel.Config), $contentModel.Albums, $fromName, $toName)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterArtist ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterArtist ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
 
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterSubject([ArtistBO]::new($contentModel.Config), $contentModel.Artists, $fromName, $toName)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterSeries ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterSeries ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
 
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterSubject([SeriesBO]::new($contentModel.Config), $contentModel.Series, $fromName, $toName)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterStudio ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterStudio ([IContentModel] $contentModel, [String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
 
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterSubject([StudioBO]::new($contentModel.Config), $contentModel.Studios, $fromName, $toName)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static RemodelFilenameFormat ([IContentModel] $contentModel, [Int] $swapElement, [Int] $withElement, [Bool] $updateCorrespondingFilename) { 
+    [Bool] Static RemodelFilenameFormat ([IContentModel] $contentModel, [Int] $swapElement, [Int] $withElement, [Bool] $updateCorrespondingFilename, [String] $contentPath) { 
         
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.RemodelFilenameFormat($swapElement, $withElement)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterSeasonEpisodeFormat ([IContentModel] $contentModel, [Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [Bool] $updateCorrespondingFilename) {
+    [Bool] Static AlterSeasonEpisodeFormat ([IContentModel] $contentModel, [Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [Bool] $updateCorrespondingFilename, [String] $contentPath) {
         
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterSeasonEpisodeFormat($padSeason, $padEpisode, $pattern)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Bool] Static AlterTrackFormat ([IContentModel] $contentModel, [Int] $padTrack, [Bool] $updateCorrespondingFilename) { 
+    [Bool] Static AlterTrackFormat ([IContentModel] $contentModel, [Int] $padTrack, [Bool] $updateCorrespondingFilename, [String] $contentPath) { 
         
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         [Bool] $alterations = $handler.AlterTrackFormat($padTrack)
         if ($updateCorrespondingFilename) {
-            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+            [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
             $handler.ApplyAllPendingFilenameChanges($filesystemProvider)
         }
         $handler.IfRequiredProvideConsoleTipsForAlter([Bool] $alterations, [Bool] $updateCorrespondingFilename)
         return $alterations
     }
 
-    [Void] ApplyAllPendingFilenameChanges([IContentModel] $contentModel) {
+    [Void] ApplyAllPendingFilenameChanges([IContentModel] $contentModel, [String] $contentPath) {
         
-        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($null, $contentModel.Config.IncludedExtensions, $true)
+        [IFilesystemProvider] $filesystemProvider = [FilesystemProvider]::new($contentPath, $contentModel.Config.IncludedExtensions, $true)
         [IModelManipulationHandler] $handler = [ModelManipulationHandler]::new($contentModel)
 
         $handler.ApplyAllPendingFilenameChanges($filesystemProvider)

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/CommandHandler.Class.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/CommandHandler.Class.psm1
@@ -365,6 +365,11 @@ class CommandHandler : ICommandHandler {
         [Int] $discrepancy = 0
         [Int] $i = 0
 
+        if (-not $filesystemProvider.HasValidPath) {
+            Write-ErrorToConsole "Error: Invalid path provided. Unable to test, abandoning action."
+            return $null
+        }
+
         # for each file
         foreach ($item in $contentModel.Content) {    
             
@@ -442,6 +447,11 @@ class CommandHandler : ICommandHandler {
 
         # if input is a path then return a minimal build, with hashes but no model subjects or properties
         if ($inputIsAPath) {
+
+            if (-not $filesystemProvider.HasValidPath) {
+                Write-ErrorToConsole "Error: Invalid path provided. Unable to compare, abandoning action."
+                return $null
+            }
 
             [ModelManipulationHandler] $handler = [ModelManipulationHandler]::new((New-ContentModel))
             $filesystemProvider.ChangePath($inputToCompare)

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/ModelManipulationHandler.Class.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/ModelManipulationHandler.Class.psm1
@@ -481,9 +481,6 @@ class ModelManipulationHandler : IModelManipulationHandler {
         $i = 0
         $this.ContentModel.Init()
         [ContentBO] $contentBO = [ContentBO]::new($this.ContentModel.Config)
-        
-        # Get the current list of files
-        [System.IO.FileInfo[]] $files = $filesystemProvider.GetFiles()
 
         # For each json object
         foreach ($indexInfo in $infoFromIndexFile) {     

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/ModelManipulationHandler.Class.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Handlers/ModelManipulationHandler.Class.psm1
@@ -68,6 +68,11 @@ class ModelManipulationHandler : IModelManipulationHandler {
 
     [Void] ApplyAllPendingFilenameChanges([IFilesystemProvider] $filesystemProvider) {
     
+        if ($filesystemProvider.HasValidPath) {
+            Write-WarnToConsole "Warning: Invalid path provided. Unable to apply changes, abandoning action."
+            return
+        }
+
         # Get all pending filename Updates
         [System.Collections.Generic.List[Content]] $pendingContent = $this.ContentModel.Content | Where-Object {$_.PendingFilenameUpdate -eq $true}
         [ContentBO] $contentBO = [ContentBO]::new($this.ContentModel.Config)
@@ -321,6 +326,11 @@ class ModelManipulationHandler : IModelManipulationHandler {
 
     [Void] Build([Bool] $loadProperties, [Bool] $generateHash, [IFilesystemProvider] $filesystemProvider) {
 
+        if (-not $filesystemProvider.HasValidPath) {
+            Write-WarnToConsole "Warning: Invalid path provided. Unable to build, abandoning action."
+            return
+        }
+        
         # Initialise
         $i = 0
         
@@ -359,6 +369,11 @@ class ModelManipulationHandler : IModelManipulationHandler {
     }
 
     [Void] Rebuild([Bool] $loadProperties, [Bool] $generateHash, [IFilesystemProvider] $filesystemProvider) {
+
+        if (-not $filesystemProvider.HasValidPath) {
+            Write-WarnToConsole "Warning: Invalid Path provided. Unable to rebuild, abandoning action."
+            return
+        }
 
         # Initialise
         $i = 0
@@ -457,6 +472,11 @@ class ModelManipulationHandler : IModelManipulationHandler {
 
     [Void] Load([System.Array] $infoFromIndexFile, [Bool] $loadProperties, [Bool] $generateHash, [IFilesystemProvider] $filesystemProvider) {
 
+        if (($loadProperties -or $generateHash) -and -not $filesystemProvider.HasValidPath) {
+            Write-WarnToConsole "Warning: Invalid path provided. Unable to load, abandoning action."
+            return
+        }
+
         # Initialise
         $i = 0
         $this.ContentModel.Init()
@@ -496,6 +516,11 @@ class ModelManipulationHandler : IModelManipulationHandler {
     }
 
     [Void] FillPropertiesAndHashWhereMissing ([Bool] $loadProperties, [Bool] $generateHash, [IFilesystemProvider] $filesystemProvider) {
+
+        if (($loadProperties -or $generateHash) -and -not $filesystemProvider.HasValidPath) {
+            Write-WarnToConsole "Warning: Invalid path provided. Unable to load, abandoning action."
+            return
+        }
 
         # Get the current list of files
         [ContentBO] $contentBO = [ContentBO]::new($this.ContentModel.Config)

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Interfaces/IContentModel.Interface.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Interfaces/IContentModel.Interface.psm1
@@ -28,33 +28,38 @@ class IContentModel : IsInterface {
     [Void] Reset() { }
     [Void] Build() { }
     [Void] Build([Bool] $loadProperties, [Bool] $generateHash) { }
+    [Void] Build([String] $contentPath) { }
+    [Void] Build([String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) { }
     [Void] Rebuild() { }
     [Void] Rebuild([Bool] $loadProperties, [Bool] $generateHash) { }
+    [Void] Rebuild([String] $contentPath) { }
+    [Void] Rebuild([String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) { }
     [Void] LoadIndex () { }
     [Void] LoadIndex ([String] $indexFilePath) { }
-    [Void] LoadIndex ([Bool] $collectInfoWhereMissing) { }
-    [Void] LoadIndex ([String] $indexFilePath, [Bool] $collectInfoWhereMissing) { }
+    [Void] LoadIndex ([String] $contentPath, [Bool] $collectInfoWhereMissing) { }
+    [Void] LoadIndex ([String] $indexFilePath, [String] $contentPath, [Bool] $collectInfoWhereMissing) { }
     [Void] SaveIndex () { }
     [Void] SaveIndex ([String] $indexFilePath) { }
-    [Void] SaveIndex ([Bool] $CollectInfoWhereMissing) { }
-    [Void] SaveIndex ([String] $indexFilePath, [Bool] $CollectInfoWhereMissing) { }
+    [Void] SaveIndex ([String] $contentPath, [Bool] $CollectInfoWhereMissing) { }
+    [Void] SaveIndex ([String] $indexFilePath, [String] $contentPath, [Bool] $CollectInfoWhereMissing) { }
     [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement) { return $null }
-    [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterActor ([String] $fromName, [String] $toName) { return $null }
-    [Bool] AlterActor ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterActor ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterAlbum ([String] $fromName, [String] $toName) { return $null }
-    [Bool] AlterAlbum ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterAlbum ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterArtist ([String] $fromName, [String] $toName) { return $null }
-    [Bool] AlterArtist ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterArtist ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterSeries ([String] $fromName, [String] $toName) { return $null }
-    [Bool] AlterSeries ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterSeries ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterStudio ([String] $fromName, [String] $toName) { return $null }
-    [Bool] AlterStudio ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterStudio ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern) { return $null }
-    [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Bool] AlterTrackFormat([Int] $padTrack) { return $null }
-    [Bool] AlterTrackFormat([Int] $padTrack, [Bool] $updateCorrespondingFilename) { return $null }
+    [Bool] AlterTrackFormat([Int] $padTrack, [String] $contentPath, [Bool] $updateCorrespondingFilename) { return $null }
     [Void] ApplyAllPendingFilenameChanges() { }
+    [Void] ApplyAllPendingFilenameChanges([String] $contentPath) { }
     [Void] Summary() { }
     [Int[]] AnalyseActorsForPossibleLabellingIssues () { return $null }
     [Int[]] AnalyseActorsForPossibleLabellingIssues ([Bool] $returnSummary) { return $null }

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/ObjectModels/ContentModel.Class.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/ObjectModels/ContentModel.Class.psm1
@@ -224,119 +224,139 @@ class ContentModel : IContentModel {
     }
 
     [Void] Build() {
-        [CollectionManagementController]::Build($this, $false, $false)
+        [CollectionManagementController]::Build($this, $null, $false, $false)
     }
 
     [Void] Build([Bool] $loadProperties, [Bool] $generateHash) {
-        [CollectionManagementController]::Build($this, $loadProperties, $generateHash)
+        [CollectionManagementController]::Build($this, $null, $loadProperties, $generateHash)
+    }
+
+    [Void] Build([String] $contentPath) {
+        [CollectionManagementController]::Build($this, $contentPath, $false, $false)
+    }
+
+    [Void] Build([String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) {
+        [CollectionManagementController]::Build($this, $contentPath, $loadProperties, $generateHash)
     }
 
     [Void] Rebuild() {
-        [CollectionManagementController]::Rebuild($this, $false, $false)
+        [CollectionManagementController]::Rebuild($this, $null, $false, $false)
     }
 
     [Void] Rebuild([Bool] $loadProperties, [Bool] $generateHash) {
-        [CollectionManagementController]::Rebuild($this, $loadProperties, $generateHash)
+        [CollectionManagementController]::Rebuild($this, $null, $loadProperties, $generateHash)
+    }
+
+    [Void] Rebuild([String] $contentPath) {
+        [CollectionManagementController]::Rebuild($this, $contentPath, $false, $false)
+    }
+
+    [Void] Rebuild([String] $contentPath, [Bool] $loadProperties, [Bool] $generateHash) {
+        [CollectionManagementController]::Rebuild($this, $contentPath, $loadProperties, $generateHash)
     }
 
     [Void] LoadIndex () {
-        [CollectionManagementController]::Load($this, ".\Index.json", $false, $false)
+        [CollectionManagementController]::Load($this, ".\Index.json", $false, $false, $null)
     }
 
     [Void] LoadIndex ([String] $indexFilePath) {
-        [CollectionManagementController]::Load($this, $indexFilePath, $false, $false)
+        [CollectionManagementController]::Load($this, $indexFilePath, $false, $false, $null)
     }
 
-    [Void] LoadIndex ([Bool] $collectInfoWhereMissing) {
-        [CollectionManagementController]::Load($this, ".\Index.json", $collectInfoWhereMissing, $collectInfoWhereMissing)
+    [Void] LoadIndex ([String] $contentPath, [Bool] $collectInfoWhereMissing) {
+        [CollectionManagementController]::Load($this, ".\Index.json", $collectInfoWhereMissing, $collectInfoWhereMissing, $contentPath)
     }
 
-    [Void] LoadIndex ([String] $indexFilePath, [Bool] $collectInfoWhereMissing) {
-        [CollectionManagementController]::Load($this, $indexFilePath, $collectInfoWhereMissing, $collectInfoWhereMissing)
+    [Void] LoadIndex ([String] $indexFilePath, [String] $contentPath, [Bool] $collectInfoWhereMissing) {
+        [CollectionManagementController]::Load($this, $indexFilePath, $collectInfoWhereMissing, $collectInfoWhereMissing, $contentPath)
     }
 
     [Void] SaveIndex () {
-        [CollectionManagementController]::Save($this, ".\Index.json", $false, $false)
+        [CollectionManagementController]::Save($this, ".\Index.json", $false, $false, $null)
     }
 
     [Void] SaveIndex ([String] $indexFilePath) {
-        [CollectionManagementController]::Save($this, $indexFilePath, $false, $false)
+        [CollectionManagementController]::Save($this, $indexFilePath, $false, $false, $null)
     }
 
-    [Void] SaveIndex ([Bool] $CollectInfoWhereMissing) {
-        [CollectionManagementController]::Save($this, ".\Index.json", $collectInfoWhereMissing, $collectInfoWhereMissing)
+    [Void] SaveIndex ([String] $contentPath, [Bool] $CollectInfoWhereMissing) {
+        [CollectionManagementController]::Save($this, ".\Index.json", $collectInfoWhereMissing, $collectInfoWhereMissing, $contentPath)
     }
 
-    [Void] SaveIndex ([String] $indexFilePath, [Bool] $CollectInfoWhereMissing) {
-        [CollectionManagementController]::Save($this, $indexFilePath, $collectInfoWhereMissing, $collectInfoWhereMissing)
+    [Void] SaveIndex ([String] $indexFilePath, [String] $contentPath, [Bool] $CollectInfoWhereMissing) {
+        [CollectionManagementController]::Save($this, $indexFilePath, $collectInfoWhereMissing, $collectInfoWhereMissing, $contentPath)
     }
 
     [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement) {
-        return [CollectionManagementController]::RemodelFilenameFormat($this, $swapElement, $withElement, $false)
+        return [CollectionManagementController]::RemodelFilenameFormat($this, $swapElement, $withElement, $false, $null)
     }
 
-    [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::RemodelFilenameFormat($this, $swapElement, $withElement, $updateCorrespondingFilename)
+    [Bool] RemodelFilenameFormat ([Int] $swapElement, [Int] $withElement, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::RemodelFilenameFormat($this, $swapElement, $withElement, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterActor ([String] $fromName, [String] $toName) {
-        return [CollectionManagementController]::AlterActor($this, $fromName, $toName, $false)
+        return [CollectionManagementController]::AlterActor($this, $fromName, $toName, $false, $null)
     }
 
-    [Bool] AlterActor ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterActor($this, $fromName, $toName, $updateCorrespondingFilename)
+    [Bool] AlterActor ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterActor($this, $fromName, $toName, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterAlbum ([String] $fromName, [String] $toName) {
-        return [CollectionManagementController]::AlterAlbum($this, $fromName, $toName, $false)
+        return [CollectionManagementController]::AlterAlbum($this, $fromName, $toName, $false, $null)
     }
 
-    [Bool] AlterAlbum ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterAlbum($this, $fromName, $toName, $updateCorrespondingFilename)
+    [Bool] AlterAlbum ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterAlbum($this, $fromName, $toName, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterArtist ([String] $fromName, [String] $toName) {
-        return [CollectionManagementController]::AlterArtist($this, $fromName, $toName, $false)
+        return [CollectionManagementController]::AlterArtist($this, $fromName, $toName, $false, $null)
     }
 
-    [Bool] AlterArtist ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterArtist($this, $fromName, $toName, $updateCorrespondingFilename)
+    [Bool] AlterArtist ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterArtist($this, $fromName, $toName, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterSeries ([String] $fromName, [String] $toName) {
-        return [CollectionManagementController]::AlterSeries($this, $fromName, $toName, $false)
+        return [CollectionManagementController]::AlterSeries($this, $fromName, $toName, $false, $null)
     }
 
-    [Bool] AlterSeries ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterSeries($this, $fromName, $toName, $updateCorrespondingFilename)
+    [Bool] AlterSeries ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterSeries($this, $fromName, $toName, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterStudio ([String] $fromName, [String] $toName) {
-        return [CollectionManagementController]::AlterStudio($this, $fromName, $toName, $false)
+        return [CollectionManagementController]::AlterStudio($this, $fromName, $toName, $false, $null)
     }
 
-    [Bool] AlterStudio ([String] $fromName, [String] $toName, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterStudio($this, $fromName, $toName, $updateCorrespondingFilename)
+    [Bool] AlterStudio ([String] $fromName, [String] $toName, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterStudio($this, $fromName, $toName, $updateCorrespondingFilename, $contentPath)
     }
 
     [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern) {
-        return [CollectionManagementController]::AlterSeasonEpisodeFormat($this, $padSeason, $padEpisode, $pattern, $false)
+        return [CollectionManagementController]::AlterSeasonEpisodeFormat($this, $padSeason, $padEpisode, $pattern, $false, $null)
     }
     
-    [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterSeasonEpisodeFormat($this, $padSeason, $padEpisode, $pattern, $updateCorrespondingFilename)
+    [Bool] AlterSeasonEpisodeFormat([Int] $padSeason, [Int] $padEpisode, [SeasonEpisodePattern] $pattern, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterSeasonEpisodeFormat($this, $padSeason, $padEpisode, $pattern, $updateCorrespondingFilename, $contentPath)
     } 
 
     [Bool] AlterTrackFormat([Int] $padTrack) {
-        return [CollectionManagementController]::AlterTrackFormat($this, $padTrack, $false)
+        return [CollectionManagementController]::AlterTrackFormat($this, $padTrack, $false, $null)
     }
 
-    [Bool] AlterTrackFormat([Int] $padTrack, [Bool] $updateCorrespondingFilename) {
-        return [CollectionManagementController]::AlterTrackFormat($this, $padTrack, $updateCorrespondingFilename)
+    [Bool] AlterTrackFormat([Int] $padTrack, [String] $contentPath, [Bool] $updateCorrespondingFilename) {
+        return [CollectionManagementController]::AlterTrackFormat($this, $padTrack, $updateCorrespondingFilename, $contentPath)
     }
 
     [Void] ApplyAllPendingFilenameChanges() {        
-        [CollectionManagementController]::ApplyAllPendingFilenameChanges($this)
+        [CollectionManagementController]::ApplyAllPendingFilenameChanges($this, $null)
+    }
+    
+    [Void] ApplyAllPendingFilenameChanges([String] $contentPath) {        
+        [CollectionManagementController]::ApplyAllPendingFilenameChanges($this, $contentPath)
     }
 
     [Void] Summary() {

--- a/PS.MediaCollectionManagement/CollectionManagement/Using/Providers/FilesystemProvider.Class.psm1
+++ b/PS.MediaCollectionManagement/CollectionManagement/Using/Providers/FilesystemProvider.Class.psm1
@@ -23,6 +23,7 @@ class FilesystemProvider : IFilesystemProvider {
     #region Properties
     [Bool] Hidden $_DisposeShellOnDispose = $false
     [Bool] Hidden $_ActSilently = $false
+    [Bool] Hidden $_HasValidPath = $false
     [String] Hidden $_AbsolutePath
     [String[]] Hidden $_IncludedExtensions
     [System.Array] Hidden $_fileCache
@@ -38,6 +39,7 @@ class FilesystemProvider : IFilesystemProvider {
         $this._ActSilently = $actSilently
 
         $this | Add-Member -Name "ActingSilently" -MemberType AliasProperty -Value "_ActSilently"
+        $this | Add-Member -Name "HasValidPath" -MemberType Alias -Value "_HasValidPath"
     }
     #endregion Constructors
     
@@ -54,9 +56,11 @@ class FilesystemProvider : IFilesystemProvider {
             }
         }
         else {
+            $this._HasValidPath = $false
             throw [System.IO.DirectoryNotFoundException] "System.IO.DirectoryNotFoundException: Unable to resolve path as it does not exist."
         }
         $this._fileCache = $null
+        $this._HasValidPath = $true
     }
 
     [System.IO.FileInfo[]] GetFiles () {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $contentModel.Build()
 # or if you want to include file matadata and generate hashes too
 $contentModel.Build($true, $true)
 
-# of with pathing
+# or with pathing
 $contentModel.Build(".\..\MyMediaFolder", $true, $true)
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Comparing models
 Compare-ContentModels $contentModel ".\Index.json"
 Compare-ContentModels ".\IndexA.json" ".\IndexB.json"
 Compare-ContentModels $contentModelA $contentModelB 
-Compare-ContentModel ".\..\MyMediaFolder" ".\Index.json"
-Compare-ContentModel ".\..\MyMediaFolder" $contentModelA
+Compare-ContentModels ".\..\MyMediaFolder" ".\Index.json"
+Compare-ContentModels ".\..\MyMediaFolder" $contentModelA
 ```
 
 Copying models

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Doing other things with your models
 $contentModelCopy = Copy-ContentModel $contentModel
 $mergedContentModel = Merge-ConentModel $contentModel1 $contentModel2
 Compare-ContentModel $contentModel1 $contentModel2
+Compare-ContentModel ".\..\MyMedia" ".\Index.json"
 ```
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-PS.MCM PowerShell Module (PowerShell Media Content Management)
+PS.MCM PowerShell Module (PowerShell Media Collection Management)
 =============
-This is a filesystem media content management module. Its purpose is to help manage a well defined file naming structure, as well as track file integrity for files under management. It works by capturing information about files from properties, hash and filename, then builds a object graph based on the naming structure. From there the user can identify filename inconsistencies, perform a range of bulk alters and updates, check integrity, compare models, copy and merge models, check spelling, etc. The user can also save models to a structured json file, which can then be reloaded at a later time to re-compare against the filesystem or other models.
+This is a filesystem media collection management module. Its purpose is to help manage a well defined file naming structure, as well as track file integrity for files under management. It works by capturing information about files from properties, hash and filename, then builds a object graph based on the naming structure. From there the user can identify filename inconsistencies, perform a range of bulk alters and updates, check integrity, compare models, copy and merge models, check spelling, etc. The user can also save models to a structured json file, which can then be reloaded at a later time to re-compare against the filesystem or other models.
 
 # Requirements
 PowerShell 5 or later.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Compare-ContentModels $contentModelA $contentModelB
 Verify Filesystem
 ```powershell
 # Validate content hashes against a content model
-Confirm-FilesystemHashes $contentModel
+Test-FilesystemHashes $contentModel
 ```
 
 Walking through your model

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Things still to be done, in progress, or recently completed:
 | ---- | ---------------- | ------ |
 | Feature | Title analysis, generating word dictionaries and spellchecking | :heavy_check_mark: |
 | Feature | Create Test Helpers to better present code coverage results | :heavy_minus_sign: |
-| Feature | Allow content model methods to select paths, giving greater control regardless of your current filesystem location. | :construction: |
+| Feature | Allow content model methods to select paths, giving greater control regardless of your current filesystem location. | :heavy_check_mark: |
 | Feature | Be able to compare a model directly with the filesystem | :heavy_check_mark: |
 | Feature | Custom dictionaries | :heavy_minus_sign: |
 
@@ -141,11 +141,11 @@ Where:
     - Manage auto output indenting 
     - Implement a mock console whose output can then be tested using Pester
     - Output colourful custom formatted tables
-- Implementing classes that use console enums as parameters in their public methods is problematic in PowerShell. In part this is because PowerShell is really a language of two halves, an OO and a procedural implementation. If we want to export an enum from a Module in PowerShell we have two options, each with their limitations. We either define them as .net enums (Add-Type), or we need to 'using' a module that contains the PowerShell enums. To avoid these limitations, this module implements enums twice, one for class definitions and the parser, and one for console users. For a full explanation, please refer to the comment block where these types are defined.
+- Implementing classes that use console enums as parameters in their public methods is problematic in PowerShell. In part this is because PowerShell is really a language of two halves, an OO and a procedural implementation. If we want to export an enum from a Module in PowerShell we have two options, each with their limitations. We either define them as .net enums (Add-Type), or we need to 'using' a module that contains the PowerShell enums. The problems are that; 'Add-Type' isn't available at parse time, 'using' requires the end user to know the structure of the module if they need to use the types (which this module does), and 'using' types has known issues all the way to PowerShell v7 (refer to logged issues in the PowerShell repos). To avoid these limitations, this module implements enums twice, one for class definitions and the parser, and one for console users. For a full explanation, please refer to the comment block where these types are defined.
 - PowerShell doesn't implement abstract classes or interfaces. To get around this limitation, this module implements pseudo abstract and pseudo interfaces with ordinary classes and a little bit of reflection.
 - Interfaces then allow the module to implement dependency injection (DI) with formal contracts.
-- Currently the spellcheck features require a local install of Microsoft Word. This was done so spellchecking could run exclusively from the local machine. However the feature has implemented as a DI provider, that abstracts away implementation specifics. This will more easily allow other implementations to be substituted or added in the future. 
-- I know The code is still pretty messy. Like most coded messes it started out as a 'I wonder if I could' thought experiment. I wasn't sure exactly how I wanted the code to work, what I was building, or even if it was worth maintaining once I had something. But now that I'm actively using it on my various multimedia archives, and I'm happy with the core functionality, I have a sense of the architecture I want. Now I can start to refactor with purpose towards 'go well' principles (thanks Bob).  
+- The current implementation of the SpellcheckProvider interface require a local install of Microsoft Word. This was done so spellchecking could run exclusively from the local machine, and to a very high standard. However because providers have been implemented with dependency injection, this will more easily allow alternate implementations to be substituted or added in the future. 
+- I know The code is still a little messy. Like most coded messes it started out as a 'I wonder if I could' thought experiment. I wasn't sure exactly how I wanted the code to work, what I was building, or even if it was worth maintaining once I had something. But now that I'm actively using it on my various multimedia archives, and I'm happy with the core functionality, I have a sense of the architecture I want. So I'm progressively refactor the code with purpose towards 'go well' principles (thanks Uncle Bob).  
 
 # Developer tips
 - This module has been implemented using Visual Studio Code, and is known to work well with this IDE.
@@ -159,7 +159,3 @@ Would like to thank/credit a bunch of contributors and the community ...
 - [gravejester](https://github.com/gravejester) for the PowerShell implementation of Levenshtein string similarity functions.
 - Pretty much everyone on [StackOverflow](https://stackoverflow.com/), for pretty much having answers to every questions ever conceived (except PowerShell Interfaces :P).
 - The [Pester community](https://github.com/pester/Pester), for creating an awesome PowerShell testing framework.
-
-
-
- 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ $contentModel.Config.OverrideFilenameSplitter(",")
 
 Building a model from the filesystem content
 ```powershell
-# Create a content model
+# Build a content model
 $contentModel.Build()
 
 # or if you want to include file matadata and generate hashes too
 $contentModel.Build($true, $true)
+
+# of with pathing
+$contentModel.Build(".\..\MyMediaFolder", $true, $true)
 ```
 
 Saving a model

--- a/README.md
+++ b/README.md
@@ -66,10 +66,24 @@ $contentModel.LoadIndex(".\Index.json")
 
 Comparing models
 ```powershell
-# Load a content model
+# Compare a content model
 Compare-ContentModels $contentModel ".\Index.json"
 Compare-ContentModels ".\IndexA.json" ".\IndexB.json"
 Compare-ContentModels $contentModelA $contentModelB 
+Compare-ContentModel ".\..\MyMediaFolder" ".\Index.json"
+Compare-ContentModel ".\..\MyMediaFolder" $contentModelA
+```
+
+Copying models
+```powershell
+# Create a new memory (independent) copy a content model
+$contentModelCopy = Copy-ContentModel $contentModel
+```
+
+Merging models
+```powershell
+# Create a new memory (independent) merged copy a content model
+$mergedContentModel = Merge-ConentModel $contentModel1 $contentModel2
 ```
 
 Verify Filesystem
@@ -99,15 +113,6 @@ Altering your model
 # Try things like
 $contentModel.AlterArtist("Foo", "Bar")
 $contentModel.AlterSeasonEpisodeFormat(2, 2, [SeasonEpisodePattern]::Uppercase_S0E0, $false)
-```
-
-Doing other things with your models
-```powershell
-# Try things like
-$contentModelCopy = Copy-ContentModel $contentModel
-$mergedContentModel = Merge-ConentModel $contentModel1 $contentModel2
-Compare-ContentModel $contentModel1 $contentModel2
-Compare-ContentModel ".\..\MyMedia" ".\Index.json"
 ```
 
 # Roadmap


### PR DESCRIPTION
All primary model methods now have the ability to specify paths. Please note, this is known to work for current directory end to end, but alternate paths won't be fully tested until I refactor the automated test stack.